### PR TITLE
Revised to support `DeferredChannels` and a `@defer` macro for `Remot…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,44 @@
 [![codecov](https://codecov.io/gh/invenia/DeferredFutures.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/DeferredFutures.jl)
 
 A `DeferredFuture` is like a regular Julia `Future`, but is initialized when `put!` is called on it.
-This means that the data in the `DeferredFuture` lives with the process the data was created on. 
+This means that the data in the `DeferredFuture` lives with the process the data was created on.
 The process the `DeferredFuture` itself lives on never needs to fetch the data to its process.
 This is useful when there is a lightweight controller process which handles scheduling work on and transferring data between multiple machines.
 
 ## Usage
 
 Use a `DeferredFuture` as you would a `Future`.
+```julia
+julia> DeferredFuture()
+DeferredFutures.DeferredFuture(Future(1,1,3,Nullable{Any}()))
 
-Note that `DeferredFuture(n)` does not control where the data lives, only where the `Future` which refers to the data lives. 
+julia> DeferredFuture(3)
+DeferredFutures.DeferredFuture(Future(3,1,4,Nullable{Any}()))
+```
+
+You can also use a `DeferredChannel` as you would a `RemoteChannel`.
+```julia
+julia> DeferredChannel(()->Channel{Int}(10), 4)
+DeferredFutures.DeferredChannel(Future(4,1,5,Nullable{Any}()),#3)
+
+julia> DeferredChannel(4)
+DeferredFutures.DeferredChannel(Future(4,1,6,Nullable{Any}()),DeferredFutures.#2)
+
+julia> DeferredChannel(4, 128; content=Int)
+DeferredFutures.DeferredChannel(Future(4,1,2,Nullable{Any}()),DeferredFutures.#2)
+```
+Note that `DeferredChannel()` will create a `RemoteChannel` with `RemoteChannel(()->Channel{Any}(32), myid())` by default.
+
+Furthermore, `@defer` can be used when creating a `Future` or `RemoteChannel` to create their deferred counterparts.
+```julia
+julia> @defer Future()
+DeferredFutures.DeferredFuture(Future(1,1,2,Nullable{Any}()))
+
+julia> @defer RemoteChannel(()->Channel{Int}(10))
+DeferredFutures.DeferredChannel(Future(1,1,1,Nullable{Any}()),#1)
+```
+
+Note that `DeferredFuture(n)` does not control where the data lives, only where the `Future` which refers to the data lives.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ DeferredFutures.DeferredChannel(Future(4,1,6,Nullable{Any}()),DeferredFutures.#2
 julia> DeferredChannel(4, 128; content=Int)
 DeferredFutures.DeferredChannel(Future(4,1,2,Nullable{Any}()),DeferredFutures.#2)
 ```
-Note that `DeferredChannel()` will create a `RemoteChannel` with `RemoteChannel(()->Channel{Any}(32), myid())` by default.
+Note that `DeferredChannel()` will create a `RemoteChannel` with `RemoteChannel(()->Channel{Any}(1), myid())` by default.
 
 Furthermore, `@defer` can be used when creating a `Future` or `RemoteChannel` to create their deferred counterparts.
 ```julia

--- a/src/DeferredFutures.jl
+++ b/src/DeferredFutures.jl
@@ -1,35 +1,88 @@
 module DeferredFutures
 
-export DeferredFuture
+export @defer, DeferredChannel, DeferredFuture
 
 using AutoHashEquals
 
-@auto_hash_equals immutable DeferredFuture <: Base.AbstractRemoteRef
+abstract DeferredRemoteRef <: Base.AbstractRemoteRef
+
+@auto_hash_equals immutable DeferredFuture <: DeferredRemoteRef
     outer::Future
 end
 
-DeferredFuture() = DeferredFuture(Future())
-DeferredFuture(pid::Integer) = DeferredFuture(Future(pid))
+DeferredFuture(pid::Integer=myid()) = DeferredFuture(Future(pid))
 
-function Base.put!(df::DeferredFuture, val)
-    rc = RemoteChannel()
-    put!(rc, val)
-    put!(df.outer, rc)
-    return df
+@auto_hash_equals immutable DeferredChannel <: DeferredRemoteRef
+    outer::Future
+    func::Function      # A function the generates the RemoteChannel
 end
 
-function Base.isready(df::DeferredFuture)
-    isready(df.outer) && isready(fetch(df.outer))
+function DeferredChannel(f::Function, pid::Integer=myid())
+    DeferredChannel(Future(pid), ()->RemoteChannel(f, pid))
 end
 
-function Base.fetch(df::DeferredFuture)
-    fetch(fetch(df.outer))
+function DeferredChannel(pid::Integer=myid(), num::Integer=32; content::DataType=Any)
+    DeferredChannel(
+        Future(pid),
+        ()->RemoteChannel(
+            ()->Channel{content}(num)
+        )
+    )
 end
 
-function Base.wait(df::DeferredFuture)
-    wait(df.outer)
-    wait(fetch(df.outer))
-    return df
+
+function Base.put!(ref::DeferredFuture, val)
+    inner = RemoteChannel()
+    put!(ref.outer, inner)
+    put!(fetch(ref.outer), val)
+
+    return ref
+end
+
+function Base.put!(ref::DeferredChannel, val)
+    # On the first call to put! create the `RemoteChannel`
+    # and `put!`` it in the `Future`
+    if !isready(ref.outer)
+        inner = ref.func()
+        put!(ref.outer, inner)
+    end
+
+    # Feature the `RemoteChannel` and `put!`
+    # the value in there
+    put!(fetch(ref.outer), val)
+
+    return ref
+end
+
+function Base.isready(ref::DeferredRemoteRef)
+    isready(ref.outer) && isready(fetch(ref.outer))
+end
+
+function Base.fetch(ref::DeferredRemoteRef)
+    fetch(fetch(ref.outer))
+end
+
+function Base.wait(ref::DeferredRemoteRef)
+    wait(ref.outer)
+    wait(fetch(ref.outer))
+    return ref
+end
+
+Base.getindex(ref::DeferredRemoteRef) = getindex(fetch(ref.outer))
+Base.close(ref::DeferredChannel) = close(fetch(ref.outer))
+Base.take!(ref::DeferredChannel) = take!(fetch(ref.outer))
+
+macro defer(ex::Expr)
+    @assert ex.head == :call
+    @assert isa(ex.args[1], Symbol)
+
+    if ex.args[1] == :Future
+        return Expr(:call, :DeferredFuture, ex.args[2:end]...)
+    elseif ex.args[1] == :RemoteChannel
+        return Expr(:call, :DeferredChannel, ex.args[2:end]...)
+    else
+        return parse("throw(AssertionError(\"Expected RemoteChannel or Future and got $(ex.args[1])\"))")
+    end
 end
 
 end # module

--- a/src/DeferredFutures.jl
+++ b/src/DeferredFutures.jl
@@ -21,10 +21,9 @@ function DeferredChannel(f::Function, pid::Integer=myid())
     DeferredChannel(Future(pid), f)
 end
 
-function DeferredChannel(pid::Integer=myid(), num::Integer=32; content::DataType=Any)
+function DeferredChannel(pid::Integer=myid(), num::Integer=1; content::DataType=Any)
     DeferredChannel(Future(pid), ()->Channel{content}(num))
 end
-
 
 function Base.put!(ref::DeferredFuture, val)
     inner = RemoteChannel()
@@ -70,10 +69,6 @@ Base.take!(ref::DeferredChannel) = take!(fetch(ref.outer))
 macro defer(ex::Expr)
     if ex.head != :call
         throw(AssertionError("Expected expression to be a function call, but got $(ex)."))
-    end
-
-    if !isa(ex.args[1], Symbol)
-        throw(AssertertionError("First argument to :call is not a Symbol."))
     end
 
     if ex.args[1] == :Future

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,8 +147,12 @@ end
 end
 
 @testset "@defer" begin
-    channel = @defer RemoteChannel(()->Channel(5))
-    other_channel = @defer RemoteChannel()
+    channel = eval(macroexpand(quote
+        @defer RemoteChannel(()->Channel(5))
+    end))
+    other_channel = eval(macroexpand(quote
+        @defer RemoteChannel()
+    end))
 
     put!(channel, 1)
     put!(channel, 2)
@@ -157,12 +161,17 @@ end
     @test take!(channel) == 1
     @test fetch(channel) == 2
 
-    fut = @defer Future()
-    other_future = @defer Future()
+    fut = eval(macroexpand(quote
+        @defer Future()
+    end))
+    other_future = eval(macroexpand(quote
+        @defer Future()
+    end))
 
     try
-        @defer Channel()
-        throw(ErrorException("@defer should fail when given `Channel()`"))
+        bad_channel = eval(macroexpand(quote
+            @defer Channel()
+        end))
     catch exc
         @test isa(exc, AssertionError)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,14 +2,20 @@ using DeferredFutures
 using Base.Test
 
 
-@testset "Comparison" begin
-    f = Future()
-
-    @test DeferredFuture(f) == DeferredFuture(f)
-    @test hash(DeferredFuture(f)) == hash(DeferredFuture(f))
+@testset "DeferredFuture Comparison" begin
+    fut = Future()
+    @test DeferredFuture(fut) == DeferredFuture(fut)
+    @test hash(DeferredFuture(fut)) == hash(DeferredFuture(fut))
 end
 
-@testset "Distributed" begin
+@testset "DeferredChannel Comparison" begin
+    fut = Future()
+    func = () -> RemoteChannel()
+    @test DeferredChannel(fut, func) == DeferredChannel(fut, func)
+    @test hash(DeferredChannel(fut, func)) == hash(DeferredChannel(fut, func))
+end
+
+@testset "Distributed DeferredFuture" begin
     top = myid()
     bottom = addprocs(1)[1]
     @everywhere using DeferredFutures
@@ -17,6 +23,7 @@ end
     try
         val = "hello"
         df = DeferredFuture(top)
+
         @test !isready(df)
 
         fut = remotecall_wait(bottom, df) do dfr
@@ -34,6 +41,37 @@ end
         rmprocs(bottom)
     end
 end
+
+@testset "Distributed DeferredChannel" begin
+    top = myid()
+    bottom = addprocs(1)[1]
+    @everywhere using DeferredFutures
+
+    try
+        val = "hello"
+        channel = DeferredChannel(top)
+
+        @test !isready(channel)
+
+        fut = remotecall_wait(bottom, channel) do dfr
+            put!(dfr, val)
+        end
+        @test fetch(fut) == channel
+        @test isready(channel)
+        @test fetch(channel) == val
+        @test wait(channel) == channel
+
+        put!(channel, "world")
+        @test take!(channel) == val
+        @test fetch(channel) == "world"
+
+        @test channel.outer.where == top
+        @test fetch(channel.outer).where == bottom
+    finally
+        rmprocs(bottom)
+    end
+end
+
 
 @testset "Allocation" begin
     rand_size = 800000000  # sizeof(rand(10000, 10000))
@@ -106,4 +144,28 @@ end
     finally
         rmprocs([left, right])
     end
+end
+
+@testset "@defer" begin
+    channel = @defer RemoteChannel(()->Channel(5))
+    other_channel = @defer RemoteChannel()
+
+    put!(channel, 1)
+    put!(channel, 2)
+
+    @test fetch(channel) == 1
+    @test take!(channel) == 1
+    @test fetch(channel) == 2
+
+    fut = @defer Future()
+    other_future = @defer Future()
+
+    try
+        @defer Channel()
+        throw(ErrorException("@defer should fail when given `Channel()`"))
+    catch exc
+        @test isa(exc, AssertionError)
+    end
+
+    close(channel)
 end


### PR DESCRIPTION
…eChannel` and `Future`.

NOTES:
- Tried including a `serialize` method to better fit the `Future` and `RemoteChannel` interfaces, but this caused tests to stall at `remotecall_wait`.
- It would be nice if we could combine `DeferredChannel` and `DeferredFuture` into a common wrapper type that dispatched on what was being wrapped.