### PR TITLE
Adds some remaining methods (getindex, finalizers, fixes close)

### DIFF
--- a/src/DeferredFutures.jl
+++ b/src/DeferredFutures.jl
@@ -4,7 +4,15 @@ export @defer, DeferredChannel, DeferredFuture, reset!
 
 using AutoHashEquals
 
-abstract DeferredRemoteRef <: Base.AbstractRemoteRef
+if VERSION >= v"0.6.0-dev.2830"
+    import Base.Distributed: AbstractRemoteRef
+elseif VERSION >= v"0.6.0-dev.2603"
+    import Base.Parallel: AbstractRemoteRef
+else
+    import Base: AbstractRemoteRef
+end
+
+abstract DeferredRemoteRef <: AbstractRemoteRef
 
 @auto_hash_equals type DeferredFuture <: DeferredRemoteRef
     outer::RemoteChannel

--- a/src/DeferredFutures.jl
+++ b/src/DeferredFutures.jl
@@ -74,7 +74,8 @@ function Base.wait(ref::DeferredRemoteRef)
     return ref
 end
 
-Base.getindex(ref::DeferredRemoteRef) = getindex(fetch(ref.outer))
+# mimics the Future/RemoteChannel indexing behaviour in Base
+Base.getindex(ref::DeferredRemoteRef, args...) = getindex(fetch(ref.outer), args...)
 Base.close(ref::DeferredChannel) = close(fetch(ref.outer))
 Base.take!(ref::DeferredChannel) = take!(fetch(ref.outer))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,94 @@ end
     @test hash(DeferredChannel(rc, func)) == hash(DeferredChannel(rc, func))
 end
 
+@testset "Finalizing" begin
+    df = DeferredFuture()
+    finalize(df)
+    @test_throws Exception isready(df)
+    @test_throws Exception fetch(df)
+    @test_throws Exception df[]
+    @test_throws Exception put!(df, 1)
+    @test_throws Exception take!(df)
+    @test_throws Exception wait(df)
+    finalize(df)
+
+    dc = DeferredChannel()
+    finalize(dc)
+    @test_throws Exception isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception close(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+    finalize(dc)
+
+    dc = DeferredChannel()
+    close(dc)
+    @test !isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+    close(dc)
+    finalize(dc)
+    @test_throws Exception isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception close(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+
+    df = DeferredFuture()
+    put!(df, 1)
+    @test df[] == 1
+    finalize(df)
+    @test_throws Exception isready(df)
+    @test_throws Exception fetch(df)
+    @test_throws Exception df[]
+    @test_throws Exception put!(df, 1)
+    @test_throws Exception take!(df)
+    @test_throws Exception wait(df)
+
+    dc = DeferredChannel()
+    put!(dc, 1)
+    @test dc[] == 1
+    finalize(dc)
+    @test_throws Exception isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception close(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+
+    dc = DeferredChannel()
+    put!(dc, 1)
+    @test dc[] == 1
+    close(dc)
+    @test isready(dc)
+    @test fetch(dc) == 1
+    @test dc[] == 1
+    @test_throws Exception put!(dc, 1)
+    @test take!(dc) == 1
+    @test !isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+    finalize(dc)
+    @test_throws Exception isready(dc)
+    @test_throws Exception fetch(dc)
+    @test_throws Exception close(dc)
+    @test_throws Exception dc[]
+    @test_throws Exception put!(dc, 1)
+    @test_throws Exception take!(dc)
+    @test_throws Exception wait(dc)
+end
+
 @testset "Distributed DeferredFuture" begin
     top = myid()
     bottom = addprocs(1)[1]
@@ -45,6 +133,14 @@ end
         @test !isready(df)
         put!(df, "world")
         @test fetch(df) == "world"
+        finalize(df)
+        @test_throws Exception isready(df)
+        @test_throws Exception fetch(df)
+        @test_throws Exception df[]
+        @test_throws Exception put!(df, 1)
+        @test_throws Exception take!(df)
+        @test_throws Exception wait(df)
+        finalize(df)
     finally
         rmprocs(bottom)
     end
@@ -83,6 +179,15 @@ end
         @test !isready(channel)
         put!(channel, "world")
         @test fetch(channel) == "world"
+        finalize(channel)
+        @test_throws Exception isready(channel)
+        @test_throws Exception fetch(channel)
+        @test_throws Exception close(channel)
+        @test_throws Exception channel[]
+        @test_throws Exception put!(channel, 1)
+        @test_throws Exception take!(channel)
+        @test_throws Exception wait(channel)
+        finalize(channel)
     finally
         rmprocs(bottom)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,9 @@ end
         @test wait(df) == df
         @test_throws ErrorException put!(df, val)
 
+        @test df[] == val
+        @test df[5] == 'o'
+
         @test df.outer.where == top
         @test fetch(df.outer).where == bottom
 
@@ -65,6 +68,9 @@ end
         @test isready(channel)
         @test fetch(channel) == val
         @test wait(channel) == channel
+
+        @test channel[] == val
+        @test channel[5] == 'o'
 
         put!(channel, "world")
         @test take!(channel) == val


### PR DESCRIPTION
`getindex` now works like it does on Base remoterefs, and cleanup for contained data can be more immediate when you use `finalize`. 

`close` used to hang when a `DeferredChannel` had not been initialized. Now it behaves like `RemoteChannel`s.

This also changes both types to mutable in order to be able to use finalizers.